### PR TITLE
ログアウト処理レビュー指摘反映

### DIFF
--- a/front/src/components/Header.vue
+++ b/front/src/components/Header.vue
@@ -1,25 +1,29 @@
 <template>
-  <div>
-    <nav class="navbar navbar-expand navbar-dark bg-dark static-top">
-      <a href="/public/pages/menu.html" style="text-decoration: none; color: white"><h1>販売管理システム</h1></a>
+  <nav class="navbar navbar-expand navbar-dark bg-dark static-top">
+    <!-- タイトル(ログイン中はクリックでメニュー画面へ遷移可能) -->
+    <h1
+      class="text-white"
+      v-on:click="onClickTitle()"
+      :style="{ cursor: isLogIn ? 'pointer' : 'default' }"
+    >
+      販売管理システム
+    </h1>
 
-      <!-- Navbar Search(なし) -->
-      <form class="d-none d-md-inline-block form-inline ml-auto mr-0 mr-md-3 my-2 my-md-0"></form>
-      <!-- Navbar -->
-      <ul class="navbar-nav ml-auto ml-md-0">
-        <div class="container text-center">
-          <div v-if="isLogIn" class="row">
-            <p class="text-white h5">ログイン中のユーザー名：</p>
-            <p v-html="userName" class="mr-3 text-white h5"></p>
-            <button class="btn-light btn-sm" v-on:click="logOut()">ログアウト</button>
-          </div>
+    <!-- ログイン中のユーザー名表示とログアウトボタン -->
+    <div class="ml-auto my-auto">
+      <div class="container text-center">
+        <div v-if="isLogIn" class="row text-white">
+          <h5>ログイン中のユーザー名：</h5>
+          <h5 v-show="userName" class="mr-3">{{ userName }}</h5>
+          <button class="btn btn-light btn-sm" v-on:click="logOut()">ログアウト</button>
         </div>
-      </ul>
-    </nav>
-  </div>
+      </div>
+    </div>
+  </nav>
 </template>
 <script>
 import * as UserUtil from "@/utils/UserUtil";
+import { isLogIn } from "../utils/UserUtil";
 export default {
   data() {
     return {
@@ -29,20 +33,28 @@ export default {
   },
   async mounted() {
     this.isLogIn = UserUtil.isLogIn();
-    const query = this.$route.query;
-    this.userName = query.userName ? query.userName : UserUtil.currentUserInfo().userName;
+    this.userName = UserUtil.currentUserInfo().userName;
   },
   methods: {
     /*
      *ログアウト処理
      */
-    logOut: async function () {
+    logOut() {
       try {
-        await UserUtil.deleteCurrentUserInfo();
+        UserUtil.deleteCurrentUserInfo();
         this.$router.push({ name: "logIn", params: { flashMsg: "ログアウトしました" } });
       } catch (e) {
-        this.msg = e.message;
         this.$router.push({ name: "logIn", params: { flashErrMsg: "ログアウト中にエラーが発生しました" } });
+      }
+    },
+
+    /*
+     *タイトル押下時処理(メニュー画面遷移)
+     */
+    onClickTitle() {
+      // ログイン中のみ、メニューへ遷移可能
+      if (this.isLogIn) {
+        this.$router.push({ name: "menu" });
       }
     },
   },

--- a/front/src/components/Header.vue
+++ b/front/src/components/Header.vue
@@ -23,7 +23,6 @@
 </template>
 <script>
 import * as UserUtil from "@/utils/UserUtil";
-import { isLogIn } from "../utils/UserUtil";
 export default {
   data() {
     return {

--- a/front/src/components/Header.vue
+++ b/front/src/components/Header.vue
@@ -1,11 +1,7 @@
 <template>
   <nav class="navbar navbar-expand navbar-dark bg-dark static-top">
     <!-- タイトル(ログイン中はクリックでメニュー画面へ遷移可能) -->
-    <h1
-      class="text-white"
-      v-on:click="onClickTitle()"
-      :style="{ cursor: isLogIn ? 'pointer' : 'default' }"
-    >
+    <h1 class="text-white" v-on:click="onClickTitle()" :style="{ cursor: isLogIn ? 'pointer' : 'default' }">
       販売管理システム
     </h1>
 
@@ -32,7 +28,10 @@ export default {
   },
   async mounted() {
     this.isLogIn = UserUtil.isLogIn();
-    this.userName = UserUtil.currentUserInfo().userName;
+    // ログイン中のみユーザー名を保持
+    if (this.isLogIn) {
+      this.userName = UserUtil.currentUserInfo().userName;
+    }
   },
   methods: {
     /*


### PR DESCRIPTION
* ログアウト処理のasyncとawait、msgの削除、
* ログアウト処理のクエリストリングから値を受け取る処理を削除
* タイトルをクリックした際にメニュー画面に遷移する処理をhrefからrouter機能を使用するように変更し、ログアウト中は該当処理を行わないように変更
* 不要なタグの削除、構造の簡素化
* navタグを囲っていたdivタグの削除
* タイトルをh5タグのみに変更し、ログアウト中はクリック不可能な仕様に変更
* タイトルとユーザー名表示の間にあったformタグの削除
* v-htmlは他のvueで使用していないので、v-showを使用する形に変更
* ログアウト中のみメニュー画面へ遷移可能に制御するonClickTitle()関数を作成